### PR TITLE
fix - 단일 게시글 조회 시, 조회 수 증가 로직을 수정한다.

### DIFF
--- a/server/http/post.http
+++ b/server/http/post.http
@@ -1,0 +1,2 @@
+### 게시글 id를 통한 조회
+GET localhost:8080/posts/1

--- a/server/src/main/java/jeju/oneroom/post/entity/Post.java
+++ b/server/src/main/java/jeju/oneroom/post/entity/Post.java
@@ -26,6 +26,8 @@ public class Post extends BaseEntity {
 
     private String title;
     private String content;
+
+    @Setter
     private int views;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -72,10 +74,6 @@ public class Post extends BaseEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
-    }
-
-    public void updateViews() {
-        this.views++;
     }
 
     // 동일 유저 검증

--- a/server/src/main/java/jeju/oneroom/post/service/PostService.java
+++ b/server/src/main/java/jeju/oneroom/post/service/PostService.java
@@ -53,7 +53,7 @@ public class PostService {
     @Transactional
     public PostDto.Response findPostByPostId(long postId) {
         Post verifiedPost = findVerifiedPost(postId);
-        verifiedPost.updateViews(); // 단일 게시글 조회 시, 조회 수 1씩 증가
+        increaseViews(verifiedPost);
 
         return postMapper.postToResponseDto(verifiedPost);
     }
@@ -99,5 +99,10 @@ public class PostService {
     public Post findVerifiedPost(long postId) {
         return postRepository.findPostById(postId)
             .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_POST));
+    }
+
+    // 조회 수 1 증가 메서드
+    private void increaseViews(Post post) {
+        post.setViews(post.getViews() + 1);
     }
 }


### PR DESCRIPTION
## 변경 사항

엔티티 내에 있는 updateViews 메서드를 제거하였습니다.

멤버 변수 views에 @Setter를 붙여주었고, Service Layer에서 +1을 처리하도록 수정하였습니다.

## 변경 이유

엔티티는 데이터를 저장하고 관리하는 성격의 메서드만 존재해야 한다고 생각합니다. (ex. Getter, Setter) - 단일 책임 원칙

기존 `views++`처럼 엔티티 내에 필드값을 1 증가시키는 로직은 비즈니스적인 요소이기 때문에, Service Layer에서 처리해야 한다고 생각합니다.