### PR TITLE
fix : enum 타입의 클래스에 대한 값 검증 로직을 추가한다.

### DIFF
--- a/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoom.java
+++ b/server/src/main/java/jeju/oneroom/messageroom/entity/MessageRoom.java
@@ -3,6 +3,7 @@ package jeju.oneroom.messageroom.entity;
 import jeju.oneroom.common.entity.BaseEntity;
 import jeju.oneroom.message.entity.Message;
 import jeju.oneroom.user.entity.User;
+import jeju.oneroom.validation.EnumValue;
 import lombok.*;
 
 import javax.persistence.*;
@@ -18,8 +19,13 @@ public class MessageRoom extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageRoomId;
 
+    /**
+     * 채팅방의 상태. 가능한 값은 'CHECK' 또는 'UNCHECK'
+     * 채팅방 최초 생성 시, 채팅방 상태의 기본값이 '읽지 않음'이 되도록 설정
+     */
     @Setter
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "varchar(255) default 'UNCHECK'")
+    @EnumValue(acceptedValues = {"CHECK", "UNCHECK"})
     @Enumerated(EnumType.STRING)
     private MessageRoomStatus messageRoomStatus;
 
@@ -43,11 +49,13 @@ public class MessageRoom extends BaseEntity {
     @OneToMany(mappedBy = "messageRoom", cascade = CascadeType.ALL)
     private Set<Message> messages = new LinkedHashSet<>();
 
+    // 코드 레벨에서, MessageRoom 엔티티 생성 시에 채팅방 상태의 기본값이 '읽지 않음'이 되도록 설정
     @Builder
     public MessageRoom(Long messageRoomId, User sender, User receiver) {
         this.messageRoomId = messageRoomId;
         this.sender = sender;
         this.receiver = receiver;
+        this.messageRoomStatus = MessageRoomStatus.UNCHECK;
     }
 
     public void setProperties(User sender, User receiver) {

--- a/server/src/main/java/jeju/oneroom/validation/EnumValidator.java
+++ b/server/src/main/java/jeju/oneroom/validation/EnumValidator.java
@@ -1,0 +1,28 @@
+package jeju.oneroom.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<EnumValue, String> {
+    private String[] acceptedValues;
+
+    @Override
+    public void initialize(EnumValue annotation) {
+        acceptedValues = annotation.acceptedValues();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+
+        for (String validValue : acceptedValues) {
+            if (validValue.equals(value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/server/src/main/java/jeju/oneroom/validation/EnumValue.java
+++ b/server/src/main/java/jeju/oneroom/validation/EnumValue.java
@@ -1,0 +1,18 @@
+package jeju.oneroom.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EnumValidator.class)
+public @interface EnumValue {
+    String[] acceptedValues();
+
+    String message() default "Invalid value. Accepted values are {acceptedValues}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## 개요
- enum 클래스 안의 필드값만 들어올 수 있도록 커스텀 어노테이션을 만들었습니다.

## 변경사항
- EnumValue 인터페이스 추가
- EnumValidator 클래스 추가
- MessageRoom 엔티티의 MessageRoomStatus 타입의 필드값에 해당 어노테이션 추가

## 참고사항
추후 추가될 수 있는 enum 타입의 클래스에도 적용할 수 있도록 인터페이스로 추상화시켜두었습니다.