### PR TITLE
Temp: findPostById()에 대한 Querydsl 적용 해제

### DIFF
--- a/server/src/main/java/jeju/oneroom/domain/houseinfo/entity/HouseInfo.java
+++ b/server/src/main/java/jeju/oneroom/domain/houseinfo/entity/HouseInfo.java
@@ -60,8 +60,9 @@ public class HouseInfo extends BaseEntity {
     private Coordinate coordinate;
 
     @Builder
-    public HouseInfo(String mainPurpsCdNm, String houseName, String buildUes, String buildingStructure, int houseHold, String useAprDay, int grndFloor, int ugrndFloor,
+    private HouseInfo(Long id, String mainPurpsCdNm, String houseName, String buildUes, String buildingStructure, int houseHold, String useAprDay, int grndFloor, int ugrndFloor,
                      int elevator, String platPlc, Rate rate, Area area, List<Review> reviews, Coordinate coordinate) {
+        this.id = id;
         this.mainPurpsCdNm = mainPurpsCdNm;
         this.houseName = houseName;
         this.buildUes = buildUes;

--- a/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
@@ -70,7 +70,7 @@ public class PostController {
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }
 
-    // 주소를 통한 다중 게시글 조회 (최신순)
+    /*// 주소를 통한 다중 게시글 조회 (최신순)
     @GetMapping("/search-address")
     public ResponseEntity<MultiResponseDto<PostDto.SimpleResponseDto>> getPostsByAddress(@RequestParam("query") String query,
                                                                                          @RequestParam int page,
@@ -98,7 +98,7 @@ public class PostController {
         Page<PostDto.SimpleResponseDto> findPosts = postService.findAllPost(page, size);
 
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
-    }
+    }*/
 
     // post-id로 단일 게시글 삭제
     @DeleteMapping("/{post-id}")

--- a/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    
+    Optional<Post> findPostById(Long id);
 
     // 단일 사용자의 모든 게시글 조회
     Page<Post> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);

--- a/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
@@ -64,7 +64,7 @@ public class PostService {
             .map(postMapper::postToSimpleResponseDto);
     }
 
-    // 제목을 통한 다중 게시글 최신순으로 조회
+    /*// 제목을 통한 다중 게시글 최신순으로 조회
     public Page<PostDto.SimpleResponseDto> findPostsByTitle(String title, int page, int size) {
         return postRepository.findPostsByTitleContains(title, PageRequest.of(page - 1, size))
             .map(postMapper::postToSimpleResponseDto);
@@ -80,7 +80,7 @@ public class PostService {
     public Page<PostDto.SimpleResponseDto> findPostsByHouseInfos(List<HouseInfo> houseInfos, int page, int size) {
         return postRepository.findPostsByHouseInfoIn(houseInfos, PageRequest.of(page - 1, size))
             .map(postMapper::postToSimpleResponseDto);
-    }
+    }*/
 
     // 게시글 id로 단일 게시글 삭제
     @Transactional


### PR DESCRIPTION
Querydsl 적용 전의 API 성능을 측정하기 위해 임시로 Querydsl 적용 해제
-> `findPostById()` 관련해서만