### PR TITLE
refactor: 단일 게시글 조회 API 성능 개선

### DIFF
--- a/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.util.List;
 
 @Validated
 @RestController
@@ -76,36 +77,36 @@ public class PostController {
         
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }
-
-    /*// 주소를 통한 다중 게시글 조회 (최신순)
+    
+    // 주소를 통한 다중 게시글 조회 (최신순)
     @GetMapping("/search-address")
     public ResponseEntity<MultiResponseDto<PostDto.SimpleResponseDto>> getPostsByAddress(@RequestParam("query") String query,
                                                                                          @RequestParam int page,
                                                                                          @RequestParam int size) {
         List<HouseInfo> houseInfos = houseInfoService.findHouseInfosByAddress(query);
         Page<PostDto.SimpleResponseDto> findPosts = postService.findPostsByHouseInfos(houseInfos, page, size);
-
+        
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }
-
+    
     // 제목을 통한 다중 게시글 조회 (최신순)
     @GetMapping("/search")
     public ResponseEntity<MultiResponseDto<PostDto.SimpleResponseDto>> getPostsByTitle(@RequestParam("query") String query,
                                                                                        @RequestParam int page,
                                                                                        @RequestParam int size) {
         Page<PostDto.SimpleResponseDto> findPosts = postService.findPostsByTitle(query, page, size);
-
+        
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }
-
+    
     // 모든 게시글 조회 (최신순)
     @GetMapping
     public ResponseEntity<MultiResponseDto<PostDto.SimpleResponseDto>> getAllPosts(@RequestParam int page,
                                                                                    @RequestParam int size) {
         Page<PostDto.SimpleResponseDto> findPosts = postService.findAllPost(page, size);
-
+        
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
-    }*/
+    }
     
     // post-id로 단일 게시글 삭제
     @DeleteMapping("/{post-id}")

--- a/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/controller/PostController.java
@@ -1,64 +1,71 @@
 package jeju.oneroom.domain.post.controller;
 
-import jeju.oneroom.domain.post.service.PostService;
-import jeju.oneroom.global.common.dto.MultiResponseDto;
 import jeju.oneroom.domain.houseinfo.entity.HouseInfo;
 import jeju.oneroom.domain.houseinfo.service.HouseInfoService;
 import jeju.oneroom.domain.post.dto.PostDto;
 import jeju.oneroom.domain.post.entity.Post;
+import jeju.oneroom.domain.post.service.PostService;
 import jeju.oneroom.domain.user.entity.User;
 import jeju.oneroom.domain.user.service.UserService;
+import jeju.oneroom.global.common.dto.MultiResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
-import java.util.List;
 
 @Validated
 @RestController
 @RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
-
+    
     private final UserService userService;
     private final HouseInfoService houseInfoService;
     private final PostService postService;
-
+    
     // 게시글 작성 기능
     @PostMapping
     public ResponseEntity<Long> post(@Valid @RequestBody PostDto.Post postDto) {
         HouseInfo houseInfo = houseInfoService.findVerifiedHouseInfo(postDto.getHouseInfoId());
         User user = userService.verifyExistsUserByEmail(postDto.getUserEmail());
         Post createdPost = postService.createPost(postDto, houseInfo, user);
-
+        
         return new ResponseEntity<>(createdPost.getId(), HttpStatus.CREATED);
     }
-
+    
     // 게시글 수정 기능
     @PatchMapping("/{post-id}")
     public ResponseEntity<Long> patchPost(@PathVariable("post-id") @Positive long postId,
                                           @Valid @RequestBody PostDto.Patch patchDto) {
         patchDto.setPostId(postId);
         User user = userService.verifyExistsUserByEmail(patchDto.getUserEmail());
-
+        
         Post updatedPost = postService.updatePost(user, patchDto);
-
+        
         return new ResponseEntity<>(updatedPost.getId(), HttpStatus.OK);
     }
-
+    
     // post-id로 단일 게시글 조회
     @GetMapping("/{post-id}")
     public ResponseEntity<PostDto.Response> getPost(@PathVariable("post-id") @Positive long postId) {
         PostDto.Response response = postService.findPostByPostId(postId);
-
+        
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
-
+    
     // user-id로 해당 유저가 작성한 다중 게시글 조회
     @GetMapping("/users/{user-id}")
     public ResponseEntity<MultiResponseDto<PostDto.SimpleResponseDto>> getUserPost(@PathVariable("user-id") @Positive long userId,
@@ -66,7 +73,7 @@ public class PostController {
                                                                                    @RequestParam int size) {
         User user = userService.verifyExistsUser(userId);
         Page<PostDto.SimpleResponseDto> findPosts = postService.findPostsByUserId(user, page, size);
-
+        
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }
 
@@ -99,15 +106,15 @@ public class PostController {
 
         return new ResponseEntity<>(new MultiResponseDto<>(findPosts), HttpStatus.OK);
     }*/
-
+    
     // post-id로 단일 게시글 삭제
     @DeleteMapping("/{post-id}")
     public ResponseEntity<HttpStatus> deletePost(@PathVariable("post-id") @Positive long postId,
                                                  @Valid @RequestBody PostDto.Delete deleteDto) {
         User user = userService.verifyExistsUserByEmail(deleteDto.getUserEmail());
-
+        
         postService.deletePost(user, postId);
-
+        
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/dto/PostDto.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/dto/PostDto.java
@@ -3,14 +3,20 @@ package jeju.oneroom.domain.post.dto;
 import jeju.oneroom.domain.houseinfo.dto.HouseInfoDto;
 import jeju.oneroom.domain.postcomment.dto.PostCommentDto;
 import jeju.oneroom.domain.user.dto.UserDto;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostDto {
-
+    
     @Getter
     @Builder
     @NoArgsConstructor
@@ -20,51 +26,51 @@ public class PostDto {
         @NotBlank
         @Size(min = 10, message = "최소 10자 이상 입력해주세요")
         private String title;
-
+        
         // 내용
         @NotBlank
         @Size(min = 50, message = "최소 50자 이상 입력해주세요")
         private String content;
-
+        
         // houseInfo와 매핑하기 위한 id
         @NotNull
         private Long houseInfoId;
-
+        
         // 로그인 한 유저 정보
         @NotBlank
         @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
                 message = "올바른 이메일 형식을 입력해 주세요.")
         private String userEmail;
     }
-
+    
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Patch {
         private Long postId;
-
+        
         // 제목
         @NotBlank
         @Size(min = 10, message = "최소 10자 이상 입력해주세요")
         private String title;
-
+        
         // 내용
         @NotBlank
         @Size(min = 50, message = "최소 50자 이상 입력해주세요")
         private String content;
-
+        
         // 로그인 한 유저 정보
         @NotBlank
         @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
                 message = "올바른 이메일 형식을 입력해 주세요.")
         private String userEmail;
-
+        
         public void setPostId(Long postId) {
             this.postId = postId;
         }
     }
-
+    
     @Getter
     @Builder
     @NoArgsConstructor
@@ -76,7 +82,7 @@ public class PostDto {
                 message = "올바른 이메일 형식을 입력해 주세요.")
         private String userEmail;
     }
-
+    
     @Getter
     @Builder
     @NoArgsConstructor
@@ -94,7 +100,7 @@ public class PostDto {
         private int commentsCount; // 달린 댓글 수
         private List<PostCommentDto.Response> postComments; // 게시글에 달린 댓글 리스트
     }
-
+    
     //심플 게시글 리스트
     @Getter
     @Builder

--- a/server/src/main/java/jeju/oneroom/domain/post/entity/Post.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/entity/Post.java
@@ -1,15 +1,29 @@
 package jeju.oneroom.domain.post.entity;
 
+import jeju.oneroom.domain.houseinfo.entity.HouseInfo;
 import jeju.oneroom.domain.postcomment.entity.PostComment;
 import jeju.oneroom.domain.postlike.entity.PostLike;
-import jeju.oneroom.global.common.entity.BaseEntity;
-import jeju.oneroom.domain.houseinfo.entity.HouseInfo;
 import jeju.oneroom.domain.user.entity.User;
-import lombok.*;
+import jeju.oneroom.global.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.Formula;
 
-import javax.persistence.*;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,44 +32,45 @@ import java.util.List;
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
-
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long id;
-
+    
     private String title;
     private String content;
-
+    
     @Setter
     private int views;
-
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "houseInfo_id")
     private HouseInfo houseInfo;
-
+    
     // 게시글의 댓글 수
     @Basic(fetch = FetchType.LAZY)
     @Formula("(select count(*) from post_comment pc where pc.post_id = post_id)")
     private long commentsCount;
-
+    
     // 게시글의 좋아요 수
     @Basic(fetch = FetchType.LAZY)
     @Formula("(select count(*) from post_like pl where pl.post_id = post_id)")
     private int likes;
-
+    
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
+    
     // 게시글 삭제 시, 연관된 모든 게시글 댓글 삭제
-    @OneToMany(mappedBy = "post", orphanRemoval = true)
+    @Setter
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostComment> postComments = new ArrayList<>();
-
+    
     // 게시글 삭제 시, 연관된 모든 게시글 좋아요 삭제
     @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<PostLike> postLikes = new ArrayList<>();
-
+    
     @Builder
     public Post(String title, String content, int views, HouseInfo houseInfo, User user, List<PostComment> postComments) {
         this.title = title;
@@ -65,22 +80,22 @@ public class Post extends BaseEntity {
         this.user = user;
         this.postComments = postComments;
     }
-
+    
     public void setProperties(HouseInfo houseInfo, User user) {
         this.houseInfo = houseInfo;
         this.user = user;
     }
-
+    
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
     }
-
+    
     // 조회 수 1 증가
     public void increaseViews() {
         this.views++;
     }
-
+    
     // 동일 유저 검증
     public boolean isAuthor(User user) {
         return this.user.equals(user);

--- a/server/src/main/java/jeju/oneroom/domain/post/mapper/PostMapper.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/mapper/PostMapper.java
@@ -1,18 +1,20 @@
 package jeju.oneroom.domain.post.mapper;
 
 import jeju.oneroom.domain.houseinfo.mapper.HouseInfoMapper;
-import jeju.oneroom.domain.postcomment.mapper.PostCommentMapper;
 import jeju.oneroom.domain.post.dto.PostDto;
 import jeju.oneroom.domain.post.entity.Post;
-import org.mapstruct.*;
+import jeju.oneroom.domain.postcomment.mapper.PostCommentMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = {PostCommentMapper.class, HouseInfoMapper.class})
 public interface PostMapper {
     Post postDtoToPost(PostDto.Post postDto);
-
+    
     @Mapping(target = "writer", source = "user")
     PostDto.Response postToResponseDto(Post post);
-
+    
     @Mapping(target = "nickname", expression = "java(post.getUser().getNickname())")
     PostDto.SimpleResponseDto postToSimpleResponseDto(Post post);
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/repository/PostCustomRepository.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/repository/PostCustomRepository.java
@@ -9,16 +9,16 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PostCustomRepository {
-
+    
     // 게시글 id로 단일 게시글 조회
     Optional<Post> findPostById(long postId);
-
+    
     // 다수의 건물에 속한 모든 게시글 조회
     Page<Post> findPostsByHouseInfoIn(List<HouseInfo> houseInfos, Pageable pageable);
-
+    
     // 제목이 포함된 다중 게시글 조회
     Page<Post> findPostsByTitleContains(String title, Pageable pageable);
-
+    
     // 모든 게시글 조회
     Page<Post> findAllPosts(Pageable pageable);
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/repository/PostCustomRepositoryImpl.java
@@ -4,7 +4,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jeju.oneroom.domain.houseinfo.entity.HouseInfo;
 import jeju.oneroom.domain.post.entity.Post;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,89 +14,87 @@ import java.util.Optional;
 
 import static jeju.oneroom.domain.houseinfo.entity.QHouseInfo.houseInfo;
 import static jeju.oneroom.domain.post.entity.QPost.post;
-import static jeju.oneroom.domain.postcomment.entity.QPostComment.postComment;
 import static jeju.oneroom.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
 public class PostCustomRepositoryImpl implements PostCustomRepository {
-
+    
     private final JPAQueryFactory jpaQueryFactory;
-
+    
     @Override
     public Optional<Post> findPostById(long postId) {
-        Post post1 = jpaQueryFactory.selectFrom(post)
-            .leftJoin(post.user, user).fetchJoin()
-            .leftJoin(post.houseInfo, houseInfo).fetchJoin()
-            .leftJoin(post.postComments, postComment).fetchJoin()
-            .leftJoin(postComment.user, user).fetchJoin()
-            .where(post.id.eq(postId))
-            .fetchOne();
-
-        return Optional.ofNullable(post1);
+        Post findPost = jpaQueryFactory.selectFrom(post)
+                .leftJoin(post.user, user).fetchJoin()
+                .leftJoin(post.houseInfo, houseInfo).fetchJoin()
+                .where(post.id.eq(postId))
+                .fetchOne();
+        
+        return Optional.ofNullable(findPost);
     }
-
+    
+    
     @Override
     public Page<Post> findPostsByHouseInfoIn(List<HouseInfo> houseInfos, Pageable pageable) {
         List<Post> posts = getPostsByHouseInfoIn(houseInfos, pageable);
-
+        
         Long count = jpaQueryFactory.select(post.count())
-            .from(post)
-            .where(post.houseInfo.in(houseInfos))
-            .fetchOne();
-
+                .from(post)
+                .where(post.houseInfo.in(houseInfos))
+                .fetchOne();
+        
         return new PageImpl<>(posts, pageable, count);
     }
-
+    
     private List<Post> getPostsByHouseInfoIn(List<HouseInfo> houseInfos, Pageable pageable) {
         return jpaQueryFactory.selectFrom(post)
-            .leftJoin(post.user, user).fetchJoin()
-            .where(post.houseInfo.in(houseInfos))
-            .orderBy(post.modifiedAt.desc())
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
+                .leftJoin(post.user, user).fetchJoin()
+                .where(post.houseInfo.in(houseInfos))
+                .orderBy(post.modifiedAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
-
+    
     @Override
     public Page<Post> findPostsByTitleContains(String title, Pageable pageable) {
         List<Post> posts = getPostsByTitleContains(title, pageable);
-
+        
         Long count = jpaQueryFactory.select(post.count())
-            .from(post)
-            .where(post.title.toUpperCase().contains(title.toUpperCase()))
-            .fetchOne();
-
+                .from(post)
+                .where(post.title.toUpperCase().contains(title.toUpperCase()))
+                .fetchOne();
+        
         return new PageImpl<>(posts, pageable, count);
     }
-
+    
     private List<Post> getPostsByTitleContains(String title, Pageable pageable) {
         return jpaQueryFactory.selectFrom(post)
-            .leftJoin(post.user, user).fetchJoin()
-            .where(post.title.toUpperCase().contains(title.toUpperCase()))
-            .orderBy(post.modifiedAt.desc())
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
+                .leftJoin(post.user, user).fetchJoin()
+                .where(post.title.toUpperCase().contains(title.toUpperCase()))
+                .orderBy(post.modifiedAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
-
+    
     @Override
     public Page<Post> findAllPosts(Pageable pageable) {
         List<Post> posts = getAllPosts(pageable);
-
+        
         Long count = jpaQueryFactory.select(post.count())
-            .from(post)
-            .fetchOne();
-
+                .from(post)
+                .fetchOne();
+        
         return new PageImpl<>(posts, pageable, count);
     }
-
+    
     private List<Post> getAllPosts(Pageable pageable) {
         return jpaQueryFactory.selectFrom(post)
-            .leftJoin(post.user, user).fetchJoin()
-            .orderBy(post.modifiedAt.desc())
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
+                .leftJoin(post.user, user).fetchJoin()
+                .orderBy(post.modifiedAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     
-    Optional<Post> findPostById(Long id);
-
+    Optional<Post> findPostById(long postId);
+    
     // 단일 사용자의 모든 게시글 조회
     Page<Post> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/repository/PostRepository.java
@@ -6,11 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
-public interface PostRepository extends JpaRepository<Post, Long> {
-    
-    Optional<Post> findPostById(long postId);
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
     
     // 단일 사용자의 모든 게시글 조회
     Page<Post> findAllByUserOrderByCreatedAtDesc(User user, Pageable pageable);

--- a/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
@@ -1,13 +1,15 @@
 package jeju.oneroom.domain.post.service;
 
-import jeju.oneroom.domain.post.mapper.PostMapper;
-import jeju.oneroom.domain.post.repository.PostRepository;
-import jeju.oneroom.global.exception.BusinessLogicException;
-import jeju.oneroom.global.exception.ExceptionCode;
 import jeju.oneroom.domain.houseinfo.entity.HouseInfo;
 import jeju.oneroom.domain.post.dto.PostDto;
 import jeju.oneroom.domain.post.entity.Post;
+import jeju.oneroom.domain.post.mapper.PostMapper;
+import jeju.oneroom.domain.post.repository.PostRepository;
+import jeju.oneroom.domain.postcomment.entity.PostComment;
+import jeju.oneroom.domain.postcomment.service.PostCommentService;
 import jeju.oneroom.domain.user.entity.User;
+import jeju.oneroom.global.exception.BusinessLogicException;
+import jeju.oneroom.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -22,46 +24,51 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostService {
-
+    
     private final PostMapper postMapper;
     private final PostRepository postRepository;
-
+    private final PostCommentService postCommentService;
+    
     // 게시글 생성
     @Transactional
     public Post createPost(PostDto.Post postDto, HouseInfo houseInfo, User user) {
         Post post = postMapper.postDtoToPost(postDto);
         post.setProperties(houseInfo, user);
-
+        
         return postRepository.save(post);
     }
-
+    
     // 게시글 수정
     @Transactional
     public Post updatePost(User user, PostDto.Patch patchDto) {
         Post verifiedPost = findVerifiedPost(patchDto.getPostId());
-
+        
         if (verifiedPost.isAuthor(user)) {
             verifiedPost.update(patchDto.getTitle(), patchDto.getContent());
         } else {
             throw new BusinessLogicException(ExceptionCode.NO_PERMISSION_TO_EDIT);
         }
-
+        
         return verifiedPost;
     }
-
+    
     // 게시글 id로 단일 게시글 조회
     @Transactional
     public PostDto.Response findPostByPostId(long postId) {
         Post verifiedPost = findVerifiedPost(postId);
+        // 조회 수 1 증가
         verifiedPost.increaseViews();
-
+        
+//        List<PostComment> findPostComments = postCommentService.findPostCommentsByPost(verifiedPost);
+//        verifiedPost.setPostComments(findPostComments);
+        
         return postMapper.postToResponseDto(verifiedPost);
     }
-
+    
     // 유저의 모든 게시글 최신순으로 조회
     public Page<PostDto.SimpleResponseDto> findPostsByUserId(User user, int page, int size) {
         return postRepository.findAllByUserOrderByCreatedAtDesc(user, PageRequest.of(page - 1, size))
-            .map(postMapper::postToSimpleResponseDto);
+                .map(postMapper::postToSimpleResponseDto);
     }
 
     /*// 제목을 통한 다중 게시글 최신순으로 조회
@@ -81,23 +88,23 @@ public class PostService {
         return postRepository.findPostsByHouseInfoIn(houseInfos, PageRequest.of(page - 1, size))
             .map(postMapper::postToSimpleResponseDto);
     }*/
-
+    
     // 게시글 id로 단일 게시글 삭제
     @Transactional
     public void deletePost(User user, long postId) {
         Post verifiedPost = findVerifiedPost(postId);
-
+        
         if (verifiedPost.isAuthor(user)) {
             postRepository.deleteById(postId);
         } else {
             throw new BusinessLogicException(ExceptionCode.NO_PERMISSION_TO_DELETE);
         }
     }
-
+    
     // 게시글 id로 존재 여부 검증
     @Transactional
     public Post findVerifiedPost(long postId) {
         return postRepository.findPostById(postId)
-            .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_POST));
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_POST));
     }
 }

--- a/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
+++ b/server/src/main/java/jeju/oneroom/domain/post/service/PostService.java
@@ -59,8 +59,8 @@ public class PostService {
         // 조회 수 1 증가
         verifiedPost.increaseViews();
         
-//        List<PostComment> findPostComments = postCommentService.findPostCommentsByPost(verifiedPost);
-//        verifiedPost.setPostComments(findPostComments);
+        List<PostComment> findPostComments = postCommentService.findPostCommentsByPost(verifiedPost);
+        verifiedPost.setPostComments(findPostComments);
         
         return postMapper.postToResponseDto(verifiedPost);
     }
@@ -70,24 +70,24 @@ public class PostService {
         return postRepository.findAllByUserOrderByCreatedAtDesc(user, PageRequest.of(page - 1, size))
                 .map(postMapper::postToSimpleResponseDto);
     }
-
-    /*// 제목을 통한 다중 게시글 최신순으로 조회
+    
+    // 제목을 통한 다중 게시글 최신순으로 조회
     public Page<PostDto.SimpleResponseDto> findPostsByTitle(String title, int page, int size) {
         return postRepository.findPostsByTitleContains(title, PageRequest.of(page - 1, size))
-            .map(postMapper::postToSimpleResponseDto);
+                .map(postMapper::postToSimpleResponseDto);
     }
-
+    
     // 모든 게시글 최신순으로 조회
     public Page<PostDto.SimpleResponseDto> findAllPost(int page, int size) {
         return postRepository.findAllPosts(PageRequest.of(page - 1, size))
-            .map(postMapper::postToSimpleResponseDto);
+                .map(postMapper::postToSimpleResponseDto);
     }
-
+    
     // 다수의 건물에 속한 다중 게시글 조회
     public Page<PostDto.SimpleResponseDto> findPostsByHouseInfos(List<HouseInfo> houseInfos, int page, int size) {
         return postRepository.findPostsByHouseInfoIn(houseInfos, PageRequest.of(page - 1, size))
-            .map(postMapper::postToSimpleResponseDto);
-    }*/
+                .map(postMapper::postToSimpleResponseDto);
+    }
     
     // 게시글 id로 단일 게시글 삭제
     @Transactional

--- a/server/src/main/java/jeju/oneroom/domain/postcomment/repository/PostCommentCustomRepository.java
+++ b/server/src/main/java/jeju/oneroom/domain/postcomment/repository/PostCommentCustomRepository.java
@@ -1,12 +1,17 @@
 package jeju.oneroom.domain.postcomment.repository;
 
+import jeju.oneroom.domain.post.entity.Post;
 import jeju.oneroom.domain.postcomment.entity.PostComment;
 import jeju.oneroom.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface PostCommentCustomRepository {
+import java.util.List;
 
+public interface PostCommentCustomRepository {
+    
+    List<PostComment> findPostCommentsByPost(Post post);
+    
     // 특정 유저가 작성한 모든 게시글 댓글 조회
     Page<PostComment> findPostCommentsByUser(User user, Pageable pageable);
 }

--- a/server/src/main/java/jeju/oneroom/domain/postcomment/repository/PostCommentCustomRepositoryImpl.java
+++ b/server/src/main/java/jeju/oneroom/domain/postcomment/repository/PostCommentCustomRepositoryImpl.java
@@ -1,35 +1,49 @@
 package jeju.oneroom.domain.postcomment.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jeju.oneroom.domain.post.entity.Post;
 import jeju.oneroom.domain.postcomment.entity.PostComment;
 import jeju.oneroom.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 import static jeju.oneroom.domain.post.entity.QPost.post;
 import static jeju.oneroom.domain.postcomment.entity.QPostComment.postComment;
+import static jeju.oneroom.domain.user.entity.QUser.user;
 
 @Repository
 @RequiredArgsConstructor
 public class PostCommentCustomRepositoryImpl implements PostCommentCustomRepository {
-
+    
     private final JPAQueryFactory jpaQueryFactory;
-
+    
+    @Override
+    public List<PostComment> findPostCommentsByPost(Post post) {
+        return jpaQueryFactory
+                .selectFrom(postComment)
+                .leftJoin(postComment.user, user).fetchJoin()
+                .where(postComment.post.id.eq(post.getId()))
+                .orderBy(postComment.createdAt.asc())
+                .fetch();
+    }
+    
     @Override
     public Page<PostComment> findPostCommentsByUser(User user, Pageable pageable) {
         List<PostComment> postComments = getPostCommentsByUser(user, pageable);
-
+        
         Long count = jpaQueryFactory.select(postComment.count())
                 .from(postComment)
                 .where(postComment.user.eq(user))
                 .fetchOne();
-
+        
         return new PageImpl<>(postComments, pageable, count);
     }
-
+    
     private List<PostComment> getPostCommentsByUser(User user, Pageable pageable) {
         return jpaQueryFactory.selectFrom(postComment)
                 .leftJoin(postComment.post, post).fetchJoin()

--- a/server/src/main/java/jeju/oneroom/domain/postcomment/service/PostCommentService.java
+++ b/server/src/main/java/jeju/oneroom/domain/postcomment/service/PostCommentService.java
@@ -1,13 +1,13 @@
 package jeju.oneroom.domain.postcomment.service;
 
+import jeju.oneroom.domain.post.entity.Post;
 import jeju.oneroom.domain.postcomment.dto.PostCommentDto;
+import jeju.oneroom.domain.postcomment.entity.PostComment;
 import jeju.oneroom.domain.postcomment.mapper.PostCommentMapper;
 import jeju.oneroom.domain.postcomment.repository.PostCommentRepository;
+import jeju.oneroom.domain.user.entity.User;
 import jeju.oneroom.global.exception.BusinessLogicException;
 import jeju.oneroom.global.exception.ExceptionCode;
-import jeju.oneroom.domain.post.entity.Post;
-import jeju.oneroom.domain.postcomment.entity.PostComment;
-import jeju.oneroom.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -15,54 +15,62 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class PostCommentService {
-
+    
     private final PostCommentMapper postCommentMapper;
     private final PostCommentRepository postCommentRepository;
-
+    
     // 게시판 댓글 생성
     public PostComment createPostComment(PostCommentDto.Post postDto, Post post, User user) {
         PostComment postComment = postCommentMapper.postDtoToPostComment(postDto);
         postComment.setProperties(post, user);
-
+        
         return postCommentRepository.save(postComment);
     }
-
+    
     // 게시판 댓글 수정
     public PostComment updatePostComment(User user, PostCommentDto.Patch patchDto) {
         PostComment verifiedPostComment = findVerifiedPostComment(patchDto.getPostCommentId());
-
+        
         if (verifiedPostComment.isAuthor(user)) {
             verifiedPostComment.update(patchDto.getContent());
         } else {
             throw new BusinessLogicException(ExceptionCode.NO_PERMISSION_TO_EDIT);
         }
-
+        
         return verifiedPostComment;
     }
-
+    
     // 유저의 모든 게시글 댓글 최신순으로 조회
     @Transactional(readOnly = true)
     public Page<PostCommentDto.Response> findPostCommentsByUser(User user, int page, int size) {
         return postCommentRepository.findPostCommentsByUser(user, PageRequest.of(page - 1, size))
                 .map(postCommentMapper::postCommentToResponseDto);
     }
-
+    
+    // 특정 게시글의 모든 댓글 최신순으로 조회
+    @Transactional(readOnly = true)
+    public List<PostComment> findPostCommentsByPost(Post post) {
+        return postCommentRepository.findPostCommentsByPost(post);
+    }
+    
     // 게시판 댓글 삭제
     public void deletePostComment(User user, long postCommentId) {
         PostComment verifiedPostComment = findVerifiedPostComment(postCommentId);
-
+        
         if (verifiedPostComment.isAuthor(user)) {
             postCommentRepository.deleteById(postCommentId);
         } else {
             throw new BusinessLogicException(ExceptionCode.NO_PERMISSION_TO_DELETE);
         }
     }
-
+    
     private PostComment findVerifiedPostComment(long postCommentId) {
         return postCommentRepository.findById(postCommentId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.NOT_FOUND_POSTCOMMENT));


### PR DESCRIPTION
## 핵심 작업
단일 게시글 조회 - `findPostById` API 성능 재개선

## 이전 동작
조회한 엔티티를 response dto로 매핑하는 과정에서 user 조회에 관한 쿼리문 N+1 문제 발생했고, 여기서 API 응답 시간이 상당 부분 걸렸음

## 동작 과정
기존 전체 fetch join을 통해 한 번에 연관 엔티티를 가져오던 것에서 도메인을 나누어 각각 필요한 fetch join만 수행
이후, PostComment에 대한 데이터를 Setter 메서드를 통해 Post 엔티티에 값 할당

## 결과
response dto로 매핑하는 과정에서는 더이상 쿼리문이 호출되지 않게 됨
nGrinder를 통한 API 성능 테스트 결과(TPS, MTT) 등 대폭 개선됨

## 추후 업데이트 사항
최종 클라이언트로의 응답 데이터를 `게시글 정보 + 페이지네이션이 적용된 댓글 리스트` 형태로 개선할 필요가 있어보임